### PR TITLE
fix(ci): have dependabot PRs be prefixed with prefix commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
     directory: '/'
     schedule:
       interval: daily
+    commit-message:
+      prefix: 'chore(deps)'
 
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
       interval: daily
+    commit-message:
+      prefix: 'chore(deps)'


### PR DESCRIPTION
test if this works on my fork first